### PR TITLE
Fix image deletion endpoint

### DIFF
--- a/src/main/java/com/example/simpleshop/controller/ProductController.java
+++ b/src/main/java/com/example/simpleshop/controller/ProductController.java
@@ -87,7 +87,7 @@ public class ProductController {
     }
 
     @Operation(summary = "상품 이미지 삭제")
-    @DeleteMapping("/products/{productId}/images/{imageId}")
+    @DeleteMapping("/{productId}/images/{imageId}")
     public ResponseEntity<ApiResponse<String>> deleteImage(
             @PathVariable Long productId,
             @PathVariable Long imageId


### PR DESCRIPTION
## Summary
- fix typo in ProductController delete image path

## Testing
- `./gradlew test --no-daemon` *(fails: cannot find symbol `ProductResponseWithImage`)*

------
https://chatgpt.com/codex/tasks/task_e_68401670eaa08327a82844b087824eaa